### PR TITLE
add ILoggerAsync

### DIFF
--- a/src/Prism.Plugin.Logging.Common/Logger/ILoggerAsync.cs
+++ b/src/Prism.Plugin.Logging.Common/Logger/ILoggerAsync.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Prism.Logging.Logger
+{
+    public interface ILoggerAsync
+    {
+        Task<bool> LogAsync(string message, Category category, Priority priority);
+    }
+}


### PR DESCRIPTION
This is just interface  to implement latter in loggers (besides ILoggerFacade). If you agree with this interface, I will send latter PR with implementations. The idea is to use it later to inject loggers into future implementation of NetworkResilienceLogger.