### PR TITLE
SocketMessenger: replace SendTo (and SendToAsync) with Send (and SendAsync)

### DIFF
--- a/src/Prism.Plugin.Logging.Common/Sockets/SocketMessenger.cs
+++ b/src/Prism.Plugin.Logging.Common/Sockets/SocketMessenger.cs
@@ -83,7 +83,7 @@ namespace Prism.Logging.Sockets
                     data = data.SubArray(socket.SendBufferSize);
                 }
 
-                await socket.SendToAsync(data.ToArraySegment(), SocketFlags.None, endpoint);
+                await socket.SendAsync(data.ToArraySegment(), SocketFlags.None);
                 SaveCache(logs);
             }
 
@@ -112,7 +112,7 @@ namespace Prism.Logging.Sockets
                         data = data.SubArray(socket.SendBufferSize);
                     }
 
-                    socket.SendTo(data, endpoint);
+                    socket.Send(data);
                     SaveCache(logs);
                 }
                 return true;


### PR DESCRIPTION
Using SocketLogger with the UDP protocol results in an exception, stating that the socket is already connected, on iOS (at least on the simulator). According to [1], `sendto()` will fail with `errno` set to `EISCONN` in that case. Replacing the `SendTo()` call with `Send()` fixes this problem (the packets will be sent to the endpoint specified in `Connect()`). 

Note that this is not observed on Android, it seems that the endpoint argument of `SendTo()` is ignored.

[1] https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/sendto.2.html