### PR TITLE
fix missing colon

### DIFF
--- a/src/Prism.Plugin.Logging.Abstractions/ConsoleLoggingService.cs
+++ b/src/Prism.Plugin.Logging.Abstractions/ConsoleLoggingService.cs
@@ -7,7 +7,7 @@ namespace Prism.Logging
     {
         public void Log(string message, IDictionary<string, string> properties)
         {
-            Console.WriteLine("Logged Message");
+            Console.WriteLine("Logged Message:");
             LogInternal(message, properties);
         }
 


### PR DESCRIPTION
I noticed an inconsistency in the output generated by _ConsoleLoggingService.cs_. The `Log()`, `Report()` and `TrackEvent()` methods all output "labels" before outputting the message that is passed to them. There is a colon at the end of each label, except in the `Log()` method. This PR adds that missing colon.